### PR TITLE
pass version when setting up caso configuration

### DIFF
--- a/caso/config.py
+++ b/caso/config.py
@@ -16,8 +16,11 @@
 
 from oslo.config import cfg
 
+import caso
+
 
 def parse_args(argv, default_config_files=None):
     cfg.CONF(argv[1:],
              project='caso',
+             version=caso.__version__,
              default_config_files=default_config_files)


### PR DESCRIPTION
caso-extract --version did not show its actual version, because we did
not pass it down when setting up oslo options.