### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pbr>=0.6,!=0.7,<1.0
 oslo.config
 oslo.utils
 
-six
+six >=1.4.0
 
 python-novaclient
 python-keystoneclient


### PR DESCRIPTION
Require python-six >= 1.4.0 due to method add_metaclass(metaclass). By the way, openstack havana require six <1.4.1, so 1.4.0 is the only suitable version for Havana