### PR TITLE
Add extract_to parameter to the CLI

### DIFF
--- a/caso/extract/ceilometer.py
+++ b/caso/extract/ceilometer.py
@@ -113,7 +113,7 @@ class CeilometerExtractor(nova.OpenStackExtractor):
         # See comment in nova.py, remove TZ from the dates.
         lastrun = lastrun.replace(tzinfo=None)
         search_query = self._build_query(ks_conn.tenant_id, lastrun,
-            extract_to)
+                                         extract_to)
 
         cpu = conn.samples.list(meter_name='cpu', q=search_query)
         self._fill_cpu_metric(cpu, records)

--- a/caso/extract/ceilometer.py
+++ b/caso/extract/ceilometer.py
@@ -92,7 +92,7 @@ class CeilometerExtractor(nova.OpenStackExtractor):
                           # convert bytes to GB
                           unit_conv=lambda v: int(v / 2 ** 30))
 
-    def extract_for_tenant(self, tenant, lastrun):
+    def extract_for_tenant(self, tenant, lastrun, extract_to):
         """Extract records for a tenant from given date.
 
         This method will get information from nova, and will enhance it with
@@ -101,16 +101,19 @@ class CeilometerExtractor(nova.OpenStackExtractor):
         :param tenant: Tenant to extract records for.
         :param extract_from: datetime.datetime object indicating the date to
                              extract records from
+        :param extract_to: datetime.datetime object indicating the date to
+                             extract records to
         :returns: A dictionary of {"server_id": caso.record.Record"}
         """
         records = super(CeilometerExtractor,
-                        self).extract_for_tenant(tenant, lastrun)
+                        self).extract_for_tenant(tenant, lastrun, extract_to)
         # Try and except here
         ks_conn = self._get_keystone_client(tenant)
         conn = self._get_ceilometer_client(tenant)
         # See comment in nova.py, remove TZ from the dates.
         lastrun = lastrun.replace(tzinfo=None)
-        search_query = self._build_query(ks_conn.tenant_id, lastrun)
+        search_query = self._build_query(ks_conn.tenant_id, lastrun,
+            extract_to)
 
         cpu = conn.samples.list(meter_name='cpu', q=search_query)
         self._fill_cpu_metric(cpu, records)

--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import datetime
+
 import dateutil.parser
 from dateutil import tz
 from oslo_config import cfg

--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -13,7 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
+import datetime
 import dateutil.parser
 from dateutil import tz
 from oslo_config import cfg
@@ -35,6 +35,9 @@ opts = [
 ]
 
 cli_opts = [
+    cfg.StrOpt('extract_to',
+               help='Extract records until this date. If it is not set, '
+               'we use now'),
     cfg.StrOpt('extract_from',
                help='Extract records from this date. If it is not set, '
                'extract records from last run. If none are set, extract '
@@ -64,18 +67,20 @@ class Manager(object):
         self.extractor = extractor_class()
         self.records = None
 
-    def _extract(self, extract_from):
+    def _extract(self, extract_from, extract_to):
         self.records = {}
         for tenant in CONF.tenants:
             try:
                 records = self.extractor.extract_for_tenant(tenant,
-                                                            extract_from)
+                                                            extract_from,
+                                                            extract_to)
             except Exception:
                 records = []
                 LOG.exception("Cannot extrat records for '%s'" % tenant)
             else:
                 LOG.info("Extracted %d records for tenant '%s' from "
-                         "%s to now" % (len(records), tenant, extract_from))
+                         "%s to %s" % (len(records), tenant, extract_from,
+                         extract_to))
             self.records.update(records)
 
     def get_records(self, lastrun="1970-01-01"):
@@ -84,15 +89,22 @@ class Manager(object):
         :param lastrun: date to get records from (optional).
 
         If CONF.extract_from is present, it will be used instead of the
-        lastrun parameter.
+        lastrun parameter. If CONF.extract_to is present, it will be used
+        instead of the extract_to parameter
         """
         extract_from = CONF.extract_from or lastrun
+        extract_to = CONF.extract_to or datetime.datetime.utcnow()
 
         if isinstance(extract_from, six.string_types):
             extract_from = dateutil.parser.parse(extract_from)
+        if isinstance(extract_to, six.string_types):
+            extract_to = dateutil.parser.parse(extract_to)
 
         if extract_from.tzinfo is None:
             extract_from.replace(tzinfo=tz.tzutc())
+        if extract_to.tzinfo is None:
+            extract_to.replace(tzinfo=tz.tzutc())
+
         if self.records is None:
-            self._extract(extract_from)
+            self._extract(extract_from, extract_to)
         return self.records

--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -80,7 +80,7 @@ class Manager(object):
             else:
                 LOG.info("Extracted %d records for tenant '%s' from "
                          "%s to %s" % (len(records), tenant, extract_from,
-                         extract_to))
+                                       extract_to))
             self.records.update(records)
 
     def get_records(self, lastrun="1970-01-01"):

--- a/caso/extract/nova.py
+++ b/caso/extract/nova.py
@@ -21,8 +21,8 @@ import novaclient.client
 from oslo_config import cfg
 
 from caso.extract import base
+from caso.extract import utils
 from caso import record
-from caso.extract.utils import server_outside_interval
 
 CONF = cfg.CONF
 CONF.import_opt("site_name", "caso.extract.manager")
@@ -127,7 +127,8 @@ class OpenStackExtractor(base.BaseExtractor):
             # Since the nova API only gives you the "changes-since",
             # we need to filter the machines that changed outside
             # the interval
-            if server_outside_interval(lastrun, extract_to, started, ended):
+            if utils.server_outside_interval(lastrun, extract_to, started,
+                                             ended):
                 del records[instance_id]
                 continue
 

--- a/caso/extract/nova.py
+++ b/caso/extract/nova.py
@@ -14,16 +14,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import datetime
 import operator
 
 import dateutil.parser
-from dateutil import tz
 import novaclient.client
 from oslo_config import cfg
 
 from caso.extract import base
 from caso import record
+from caso.extract.utils import server_outside_interval
 
 CONF = cfg.CONF
 CONF.import_opt("site_name", "caso.extract.manager")
@@ -47,7 +46,7 @@ class OpenStackExtractor(base.BaseExtractor):
         conn.authenticate()
         return conn
 
-    def extract_for_tenant(self, tenant, lastrun):
+    def extract_for_tenant(self, tenant, lastrun, extract_to):
         """Extract records for a tenant from given date querying nova.
 
         This method will get information from nova.
@@ -55,14 +54,14 @@ class OpenStackExtractor(base.BaseExtractor):
         :param tenant: Tenant to extract records for.
         :param extract_from: datetime.datetime object indicating the date to
                              extract records from
+        :param extract_to: datetime.datetime object indicating the date to
+                           extract records to
         :returns: A dictionary of {"server_id": caso.record.Record"}
         """
         # Some API calls do not expect a TZ, so we have to remove the timezone
         # from the dates. We assume that all dates coming from upstream are
         # in UTC TZ.
         lastrun = lastrun.replace(tzinfo=None)
-        now = datetime.datetime.now(tz.tzutc()).replace(tzinfo=None)
-        end = now + datetime.timedelta(days=1)
 
         # Try and except here
         conn = self._get_conn(tenant)
@@ -79,7 +78,7 @@ class OpenStackExtractor(base.BaseExtractor):
         else:
             start = lastrun
 
-        aux = conn.usage.get(tenant_id, start, end)
+        aux = conn.usage.get(tenant_id, start, extract_to)
         usages = getattr(aux, "server_usages", [])
 
         images = conn.images.list()
@@ -120,13 +119,24 @@ class OpenStackExtractor(base.BaseExtractor):
             records[instance_id].disk = usage["local_gb"]
 
             started = dateutil.parser.parse(usage["started_at"])
+            if usage.get('ended_at', None) is not None:
+                ended = dateutil.parser.parse(usage["ended_at"])
+            else:
+                ended = None
+
+            # Since the nova API only gives you the "changes-since",
+            # we need to filter the machines that changed outside
+            # the interval
+            if server_outside_interval(lastrun, extract_to, started, ended):
+                del records[instance_id]
+                continue
+
             records[instance_id].start_time = int(started.strftime("%s"))
-            if usage.get("ended_at", None) is not None:
-                ended = dateutil.parser.parse(usage['ended_at'])
+            if ended is not None:
                 records[instance_id].end_time = int(ended.strftime("%s"))
                 wall = ended - started
             else:
-                wall = now - started
+                wall = extract_to - started
 
             wall = int(wall.total_seconds())
             records[instance_id].wall_duration = wall

--- a/caso/extract/utils.py
+++ b/caso/extract/utils.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2014 Spanish National Research Council (CSIC)
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def _inside_interval(start, end, date):
+    """Checks if the given date is inside the interval or not"
+
+    :param start: the start date of the interval
+    :param end: the end date of the interval
+    :param date: the date to check
+    :returns: True if it is inside, False otherwise
+    """
+    return (date >= start and date <= end)
+
+
+def server_outside_interval(start, end, vm_start, vm_end):
+    """Checks if a VM should be included in the record generation or not
+
+    If the VM ended after `end` or it started after `end` and didn't
+    finish, it shouldn't be included in the report
+
+    :param start: the start date of the interval
+    :param end: the end date of the invertal
+    :param vm_start: when the VM started
+    :param vm_end: when the VM was terminated
+    :returns: True if the VM shouldn't be included, False otherwise
+    """
+    return not _inside_interval(start, end, vm_start) or \
+        (vm_end is not None and not _inside_interval(start, end, vm_end))

--- a/caso/extract/utils.py
+++ b/caso/extract/utils.py
@@ -38,5 +38,5 @@ def server_outside_interval(start, end, vm_start, vm_end):
     :param vm_end: when the VM was terminated
     :returns: True if the VM shouldn't be included, False otherwise
     """
-    return not _inside_interval(start, end, vm_start) or \
-        (vm_end is not None and not _inside_interval(start, end, vm_end))
+    return (not _inside_interval(start, end, vm_start) or
+            (vm_end is not None and not _inside_interval(start, end, vm_end)))

--- a/caso/tests/base.py
+++ b/caso/tests/base.py
@@ -61,3 +61,7 @@ class TestCase(testtools.TestCase):
         group = kw.pop('group', None)
         for k, v in six.iteritems(kw):
             CONF.set_override(k, v, group)
+
+    def reset_flags(self):
+        """Reset flags"""
+        CONF.reset()

--- a/caso/tests/base.py
+++ b/caso/tests/base.py
@@ -63,5 +63,5 @@ class TestCase(testtools.TestCase):
             CONF.set_override(k, v, group)
 
     def reset_flags(self):
-        """Reset flags"""
+        """Reset flags."""
         CONF.reset()

--- a/caso/tests/extract/test_manager.py
+++ b/caso/tests/extract/test_manager.py
@@ -16,11 +16,11 @@
 Tests for `caso.extract.manager` module.
 """
 
+import datetime
 import uuid
 
 import dateutil.parser
 import mock
-import datetime
 
 from caso.extract import manager
 from caso.tests import base
@@ -91,7 +91,6 @@ class TestCasoManager(base.TestCase):
     def test_get_records_with_lastrun(self):
         date = "1999-12-11"
 
-        print self.flags()
         dt = dateutil.parser.parse(date)
         mock_now = datetime.datetime(2016, 4, 19, 15, 4, 14, 468060)
 

--- a/caso/tests/extract/test_manager.py
+++ b/caso/tests/extract/test_manager.py
@@ -20,6 +20,7 @@ import uuid
 
 import dateutil.parser
 import mock
+import datetime
 
 from caso.extract import manager
 from caso.tests import base
@@ -37,6 +38,7 @@ class TestCasoManager(base.TestCase):
 
     def tearDown(self):
         self.p_extractor.stop()
+        self.reset_flags()
 
         super(TestCasoManager, self).tearDown()
 
@@ -45,7 +47,7 @@ class TestCasoManager(base.TestCase):
 
         with mock.patch.object(self.manager.extractor,
                                "extract_for_tenant") as m:
-            self.manager._extract("1999-12-19")
+            self.manager._extract("1999-12-19", "2015-10-23")
             self.assertFalse(m.called)
         self.assertEqual({}, self.manager.records)
 
@@ -56,12 +58,17 @@ class TestCasoManager(base.TestCase):
         with mock.patch.object(self.manager.extractor,
                                "extract_for_tenant") as m:
             m.return_value = records
-            self.manager._extract("1999-12-19")
-            m.assert_called_once_with("bazonk", "1999-12-19")
+            self.manager._extract("1999-12-19", "2015-12-19")
+            m.assert_called_once_with("bazonk", "1999-12-19", "2015-12-19")
         self.assertEqual(records, self.manager.records)
 
     def test_get_records_wrong_extract_from(self):
         self.flags(extract_from="1999-12-99")
+        self.assertRaises(ValueError,
+                          self.manager.get_records)
+
+    def test_get_records_wrong_extract_to(self):
+        self.flags(extract_to="1999-12-99")
         self.assertRaises(ValueError,
                           self.manager.get_records)
 
@@ -70,17 +77,27 @@ class TestCasoManager(base.TestCase):
                           self.manager.get_records,
                           lastrun="1999-12-99")
 
-    def test_get_records_with_extract_from(self):
+    def test_get_records_with_extract_from_and_to(self):
         date = "1999-12-11"
+        end_date = "2015-12-11"
         dt = dateutil.parser.parse(date)
-        self.flags(extract_from=date)
+        parsed_end_date = dateutil.parser.parse(end_date)
+        self.flags(extract_from=date, extract_to=end_date)
+
         with mock.patch.object(self.manager, "_extract") as m:
             self.manager.get_records()
-            m.assert_called_with(dt)
+            m.assert_called_with(dt, parsed_end_date)
 
     def test_get_records_with_lastrun(self):
         date = "1999-12-11"
+
+        print self.flags()
         dt = dateutil.parser.parse(date)
+        mock_now = datetime.datetime(2016, 4, 19, 15, 4, 14, 468060)
+
         with mock.patch.object(self.manager, "_extract") as m:
-            self.manager.get_records(lastrun=date)
-            m.assert_called_with(dt)
+            with mock.patch('caso.extract.manager.datetime') as MockDatetime:
+                MockDatetime.datetime.utcnow.return_value = mock_now
+
+                self.manager.get_records(lastrun=date)
+                m.assert_called_with(dt, mock_now)


### PR DESCRIPTION
In order to limit the result for an interval I put this new option as a parameter in the CLI. Some comments about the pull request:

- I added some tests for this new option (only for `manager.py`). I think there was a bug in the tests, because the flags weren't being reset between tests. That's why I added  `self.reset_flags()` in `tearDown()`.
- I changed the `nova` extractor. I use the `extract_to` date instead of `now` and ignore the VMs from `records` that have been created after the end of the interval or `removed` after the interval (because the change didn't happen in the defined interval).
- The change in the `ceilometer` extractor was easy, just add the parameter to the query already in place.