### PR TITLE
Use public Keystone interface

### DIFF
--- a/caso/keystone_client.py
+++ b/caso/keystone_client.py
@@ -41,4 +41,4 @@ def get_session(conf, project):
 def get_client(conf, project):
     """Return a client for Keystone."""
     sess = get_session(conf, project)
-    return ks_client_v3.Client(session=sess)
+    return ks_client_v3.Client(session=sess, interface='public')


### PR DESCRIPTION
# Description

get_users by default uses the `admin` Keystone interface, usually with different port and non accessible host from the outside world. We don't need any admin features and the same 
API is accessible via the public interface. This PR proposes to change the default to be
`public` instead of `admin` for caso. This could be a setting if considered relevant, but should
work for most sites with `public`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
