### PR TITLE
Support for multi-region environments + documentation

### DIFF
--- a/caso/extract/nova.py
+++ b/caso/extract/nova.py
@@ -29,9 +29,15 @@ from caso import record
 
 CONF = cfg.CONF
 
+opts = [
+    cfg.StrOpt('region_name',
+               help='REGION to be claimed'),
+]
+
 CONF.import_opt("site_name", "caso.extract.base")
 CONF.import_opt("benchmark_name_key", "caso.extract.base")
 CONF.import_opt("benchmark_value_key", "caso.extract.base")
+CONF.import_opt("region_name", "caso.extract.base")
 
 LOG = log.getLogger(__name__)
 
@@ -41,8 +47,9 @@ class OpenStackExtractor(base.BaseExtractor):
         super(OpenStackExtractor, self).__init__()
 
     def _get_nova_client(self, project):
+        region_name = CONF.region_name
         session = keystone_client.get_session(CONF, project)
-        return novaclient.client.Client(2, session=session)
+        return novaclient.client.Client(2, session=session, region_name=region_name)
 
     def _get_glance_client(self, project):
         session = keystone_client.get_session(CONF, project)

--- a/doc/source/multi-region.rst
+++ b/doc/source/multi-region.rst
@@ -1,0 +1,39 @@
+============
+cASO multi-region support
+============
+
+* In case the monitored Project(s) rely on a specific region, define the following variable in the /etc/caso/caso.conf
+
+.. code-block:: bash
+ 
+  [DEFAULT]
+  region_name = <REGION>
+
+
+* In case the monitored Project(s) rely on different regions, prepare different files /etc/caso/caso-<REGION>.conf
+
+.. code-block:: bash
+
+  [DEFAULT]
+  region_name = <REGION>
+
+
+* List the Project(s) in the /etc/caso/voms.json as from the documentation
+
+.. code-block:: JSON
+
+  {
+    "Project1": {
+      "projects": ["Project1"]
+    },
+    "Project2": {
+      "projects": ["Project2"]
+    }
+  }
+
+* Execute caso-extract for each Project (and related REGION) to be monitored (Project1-REGION1, Project2-REGION2)
+
+.. code-block:: bash
+
+    /usr/bin/caso-extract --projects "Project1" --config-file /etc/caso/caso-<REGION1>.conf
+    /usr/bin/caso-extract --projects "Project2" --config-file /etc/caso/caso-<REGION2>.conf


### PR DESCRIPTION
# Description

Support to multi-region in Openstack environment.
Related documentation has been prepared.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- This change is a documentation update

# How Has This Been Tested?

New feature has been tested in an Openstack Rocky environment. Resources (VM) have been deployed on different Projects under the same Domain but relying on hypervisors from different Regions.  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
