### PR TITLE
Do not rely on f-strings

### DIFF
--- a/caso/messenger/ssm.py
+++ b/caso/messenger/ssm.py
@@ -56,9 +56,9 @@ class _SSMBaseMessenger(caso.messenger.BaseMessenger):
         utils.makedirs(CONF.ssm.output_path)
 
     def push_compute_message(self, queue, entries):
-        message = f"APEL-cloud-message: v{self.compute_version}\n"
+        message = "APEL-cloud-message: v%s\n" % self.compute_version
         aux = "%%\n".join(entries)
-        message += f"{aux}\n"
+        message += "%s\n" % aux
         queue.add(message)
 
     def push_ip_message(self, queue, entries):

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ project_urls =
 license = Apache-2
 license_file = LICENSE
 
-python-requires = >=3.6
+python-requires = >=3.5
 
 classifier =
     Development Status :: 5 - Production/Stable
@@ -27,6 +27,7 @@ classifier =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8


### PR DESCRIPTION
Unfortunately some cloud sites still are on py3.5, so lets not rely on
f-strings for now and set minimum version to 3.5
