### PR TITLE
fix: use POSIX timestamps for SSM cloud records

### DIFF
--- a/caso/messenger/ssm.py
+++ b/caso/messenger/ssm.py
@@ -16,6 +16,7 @@
 
 """Module containing the APEL SSM Messenger."""
 
+import datetime
 import json
 import typing
 import warnings
@@ -75,7 +76,7 @@ class SSMMessenger(caso.messenger.BaseMessenger):
     ):
         """Push a compute message, formatted following the CloudRecord."""
         message = f"APEL-cloud-message: v{self.version_cloud}\n"
-        aux = "%%\n".join(entries)
+        aux = "\n%%\n".join(entries)
         message += f"{aux}\n"
         queue.add(message.encode("utf-8"))
 
@@ -189,11 +190,14 @@ class SSMMessenger(caso.messenger.BaseMessenger):
         }
         for record in records:
             if isinstance(record, caso.record.CloudRecord):
-                aux = ""
+                aux = []
                 for k, v in six.iteritems(record.dict(**opts)):
                     if v is not None:
-                        aux += f"{k}: {v}\n"
-                entries_cloud.append(aux)
+                        if isinstance(v, datetime.datetime):
+                            aux.append(f"{k}: {int(v.timestamp())}")
+                        else:
+                            aux.append(f"{k}: {v}")
+                entries_cloud.append("\n".join(aux))
             elif isinstance(record, caso.record.IPRecord):
                 entries_ip.append(record.json(**opts))
             elif isinstance(record, caso.record.AcceleratorRecord):


### PR DESCRIPTION
# Description


Enforces the use of integer timestamps for all datetime fields in the
VM records

Fixes #113

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change is a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- [X] Test: generate records with a working site configuration, check the StartTime and EndTime fields.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
