### PR TITLE
Extractor timing fixes

### DIFF
--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -22,14 +22,16 @@ import os.path
 import warnings
 
 import dateutil.parser
-import six
 from dateutil import tz
-from keystoneauth1.exceptions.catalog import EmptyCatalog
-from keystoneauth1.exceptions.http import Forbidden
 from oslo_config import cfg
 from oslo_log import log
+import six
 
-from caso import keystone_client, loading
+from caso import keystone_client
+from caso import loading
+
+from keystoneauth1.exceptions.catalog import EmptyCatalog
+from keystoneauth1.exceptions.http import Forbidden
 
 cli_opts = [
     cfg.ListOpt(
@@ -154,7 +156,13 @@ class Manager(object):
         return date
 
     def write_lastrun(self, project, extract_to):
-        """Write a lastrun file for a given project."""
+        """Write a lastrun file for a given project.
+
+        The `extract_to` parameter represents the timestamp of the last
+        processed record, and the next run resumes from `extract_to + 1s` 
+        to avoid duplication while preserving continuity in the ingestion 
+        process.
+        """
         if CONF.dry_run:
             return
         lfile = f"{self.last_run_base}.{project}"

--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -159,8 +159,8 @@ class Manager(object):
         """Write a lastrun file for a given project.
 
         The `extract_to` parameter represents the timestamp of the last
-        processed record, and the next run resumes from `extract_to + 1s` 
-        to avoid duplication while preserving continuity in the ingestion 
+        processed record, and the next run resumes from `extract_to + 1s`
+        to avoid duplication while preserving continuity in the ingestion
         process.
         """
         if CONF.dry_run:

--- a/caso/extract/manager.py
+++ b/caso/extract/manager.py
@@ -22,16 +22,14 @@ import os.path
 import warnings
 
 import dateutil.parser
-from dateutil import tz
-from oslo_config import cfg
-from oslo_log import log
 import six
-
-from caso import keystone_client
-from caso import loading
-
+from dateutil import tz
 from keystoneauth1.exceptions.catalog import EmptyCatalog
 from keystoneauth1.exceptions.http import Forbidden
+from oslo_config import cfg
+from oslo_log import log
+
+from caso import keystone_client, loading
 
 cli_opts = [
     cfg.ListOpt(
@@ -155,13 +153,14 @@ class Manager(object):
             LOG.debug(f"Got '{date}' from lastrun file '{lfile}'")
         return date
 
-    def write_lastrun(self, project):
+    def write_lastrun(self, project, extract_to):
         """Write a lastrun file for a given project."""
         if CONF.dry_run:
             return
         lfile = f"{self.last_run_base}.{project}"
         with open(lfile, "w") as fd:
-            fd.write(str(datetime.datetime.now(tz.tzutc())))
+            next_from = extract_to + datetime.timedelta(seconds=1)
+            fd.write(str(next_from))
 
     @property
     def voms_map(self):
@@ -326,5 +325,5 @@ class Manager(object):
                 f"project '{project}' "
                 f"({extract_from} to {extract_to})"
             )
-            self.write_lastrun(project)
+            self.write_lastrun(project, extract_to)
         return all_records

--- a/caso/tests/extract/test_manager.py
+++ b/caso/tests/extract/test_manager.py
@@ -15,14 +15,14 @@
 """Tests for `caso.extract.manager` module."""
 
 import datetime
+import unittest
 import uuid
+from unittest import mock
 
 import dateutil.parser
+import six
 from dateutil import tz
 from oslo_config import cfg
-import six
-import unittest
-from unittest import mock
 
 from caso.extract import manager
 
@@ -248,7 +248,7 @@ class TestCasoManager(unittest.TestCase):
 
         with unittest.mock.patch.object(self.manager, "write_lastrun") as m:
             self.manager.get_records()
-            m.assert_called_once_with("bazonk")
+            m.assert_called_once_with("bazonk", unittest.mock.ANY)
 
     def test_write_lastrun(self):
         """Test that we actually write lastrun files."""


### PR DESCRIPTION
This pull request updates how the lastrun file is written in the `caso.extract.manager` module, ensuring that the timestamp reflects the end of the extraction window rather than the current time. It also updates related tests.

Changes to lastrun file logic:

* The `write_lastrun` method now takes an additional `extract_to` argument and writes `extract_to + 1 second` as the lastrun timestamp, instead of the current time, ensuring more accurate tracking of extraction windows.
* The `get_records` method is updated to pass the `extract_to` value to `write_lastrun`, aligning the lastrun file with the extraction period.

Test updates:

* The `test_write_lastrun_dry_run` test is updated to check that `write_lastrun` is called with both the project and the extraction end time, reflecting the new method signature.